### PR TITLE
Feat/issue 44

### DIFF
--- a/src/components/common/Modal/JoinRequestModal.tsx
+++ b/src/components/common/Modal/JoinRequestModal.tsx
@@ -5,27 +5,25 @@ import { studyApi } from '@/api/studyApi';
 import Selector from '../Selector';
 import { Input } from 'antd';
 import { toast } from 'react-toastify';
-import { USER_NUMBER } from '@/util/constant';
 import Loading from '@/components/Loading/Loading';
-
 const { TextArea } = Input;
 
 
 interface IProps {
-  title: string;
-  text : string;
+  userId : number;
   id : number;
   name : string;
 }
 
-const JoinRequestModal = ({title, text, id, name}: IProps) => {
+const JoinRequestModal = ({userId, id, name}: IProps) => {
+
   const [studyId, setId] = useState<number>(); 
   const [message, setMessage] = useState<string>('');
   const [open, setOpen] = useState(false);
   const [confirmLoading, setConfirmLoading] = useState(false);
   const [modalText, setModalText] = useState('Content of the modal');
   const router = useRouter()
-  const {data: getStudyList, isLoading} = studyApi.useGetUserStudyListQuery({memberId:USER_NUMBER, status:1})
+  const {data: getStudyList, isLoading} = studyApi.useGetUserStudyListQuery({memberId:userId, status:1})
   const [handleInvite] = studyApi.useInviteStudyMutation()
   const showModal = () => {
     setOpen(true);
@@ -40,7 +38,7 @@ const JoinRequestModal = ({title, text, id, name}: IProps) => {
       setConfirmLoading(true);
       
       
-      await handleInvite({'study':studyId, 'inviter':USER_NUMBER, 'invitee':id, 'msg':message})
+      await handleInvite({'study':studyId, 'inviter':userId, 'invitee':id, 'msg':message})
       setMessage('')
       toast('스터디 초대 완료')
       setOpen(false);

--- a/src/components/common/Modal/RequestModal.tsx
+++ b/src/components/common/Modal/RequestModal.tsx
@@ -4,18 +4,22 @@ import { useRouter } from "next/router";
 import { studyApi } from '@/api/studyApi';
 import { Input } from 'antd';
 import { toast } from 'react-toastify';
-import { USER_NUMBER } from '@/util/constant';
+
+interface IProps {
+  memberId : number;
+  studyId : string;
+}
 
 const { TextArea } = Input;
-
-const RequestModal = () => {
-  const [studyId, setStudyId] = useState<number>(); 
+const RequestModal = ({memberId, studyId}:IProps) => {
+  console.log(memberId);
+  
   const [message, setMessage] = useState<string>('');
   const [open, setOpen] = useState(false);
   const [confirmLoading, setConfirmLoading] = useState(false);
   const [modalText, setModalText] = useState('Content of the modal');
   const router = useRouter();
-  const {detail: param} = router.query;
+  
   const [handleJoinStudy] = studyApi.useJoinStudyMutation()
   const showModal = () => {
     setOpen(true);
@@ -23,9 +27,10 @@ const RequestModal = () => {
   // 스터디 가입 
 
   const handleOk = async() => {
+    
     try{
       setConfirmLoading(true);      
-      await handleJoinStudy({'study':Number(param), 'member':USER_NUMBER, 'msg':message})
+      await handleJoinStudy({'study':Number(studyId), 'member':memberId, 'msg':message})
       setMessage('')
       toast('스터디 가입 신청 완료')
       setOpen(false);

--- a/src/components/modify/Img.tsx
+++ b/src/components/modify/Img.tsx
@@ -1,9 +1,10 @@
 import { S } from "./style";
-import { IMG_URL } from "@/pages/mock";
-const ModifyImg = () => {
+import Image from "next/image";
+
+const ModifyImg = ({userImg}:{userImg:string}) => {
   return (
     <S.ImgContainer>
-      <img src={IMG_URL} />
+      <img src={userImg} alt="kakao profile img"/>
       <button>이미지 변경</button>
     </S.ImgContainer>
   );

--- a/src/components/study/studyInfo.tsx
+++ b/src/components/study/studyInfo.tsx
@@ -2,29 +2,24 @@ import { IMG_URL } from "@/pages/mock";
 import { S } from "./style";
 import { studyApi } from "@/api/studyApi";
 import { useRouter } from "next/router";
-import { USER_NUMBER } from "@/util/constant";
 import RequestModal from "../common/Modal/RequestModal";
 import Loading from "../Loading/Loading";
-const StudyInfo = () => {
+
+interface IProps{
+  isUserStudy: boolean;
+  memberId: number;
+}
+
+const StudyInfo = ({isUserStudy, memberId}:IProps) => {
   const router = useRouter();
   const {studyId} = router.query;  
   const {data, isLoading} = studyApi.useGetStudyInfoQuery(studyId)
-  console.log(data);
-  const [joinStudy] = studyApi.useJoinStudyMutation()
 
-  const handleJoinStudy = async () => {
-    await joinStudy({"study":studyId, "member":USER_NUMBER, "msg":'test'})
-  }
   if(isLoading) return (
     <S.Container>
       <S.Img src={IMG_URL} />
       <S.StudyInfoContainer>
         <Loading/>
-        {/* <RequestModal/> */}
-        <S.ButtonWrapper>
-          <button onClick={(e) =>{e.preventDefault(); router.push({pathname:"/study/rule", query:{param: studyId }})}}>미션 만들기</button>
-          <button onClick={(e) =>{e.preventDefault(); router.push({pathname:"/study/manage", query:{name:data.data.name, id:studyId, about:data.data.about, capacity: data.data.capacity }})}}>스터디 수정하기</button>
-        </S.ButtonWrapper>
       </S.StudyInfoContainer>
     </S.Container>
   )
@@ -34,11 +29,15 @@ const StudyInfo = () => {
       <S.StudyInfoContainer>
         <S.Title>{data.data.name}</S.Title>
         <S.About style={{color:'white'}}>{data.data.about}</S.About>
-        {/* <RequestModal/> */}
-        <S.ButtonWrapper>
-          <button onClick={(e) =>{e.preventDefault(); router.push({pathname:"/study/rule", query:{param: studyId }})}}>미션 만들기</button>
-          <button onClick={(e) =>{e.preventDefault(); router.push({pathname:"/study/manage", query:{name:data.data.name, id:studyId, about:data.data.about, capacity: data.data.capacity }})}}>스터디 수정하기</button>
-        </S.ButtonWrapper>
+        {
+          isUserStudy ? 
+          <S.ButtonWrapper>
+            <button onClick={(e) =>{e.preventDefault(); router.push({pathname:"/study/rule", query:{param: studyId }})}}>미션 만들기</button>
+            <button onClick={(e) =>{e.preventDefault(); router.push({pathname:"/study/manage", query:{name:data.data.name, id:studyId, about:data.data.about, capacity: data.data.capacity }})}}>스터디 수정하기</button>
+          </S.ButtonWrapper>
+        :
+          <RequestModal memberId={memberId} studyId={String(studyId)}/>
+        }
       </S.StudyInfoContainer>
     </S.Container>
   );

--- a/src/components/userInfo/UserInfo.tsx
+++ b/src/components/userInfo/UserInfo.tsx
@@ -1,12 +1,14 @@
 import { IMG_URL } from "@/pages/mock";
 import { S } from "./style";
-import Link from "next/link";
-import { memberApi } from "@/api/memberApi";
-import { IUserData } from "@/pages/member/[detail]";
 import { useRouter } from "next/router";
 import JoinRequestModal from "../common/Modal/JoinRequestModal";
 
-const UserInfo = ({userData}:any) => {
+interface IProps {
+  userData : any;
+  userId : string;
+}
+
+const UserInfo = ({userData, userId}:IProps) => {
   const router = useRouter()
   const isMypage = Object.keys(router.query).length === 0 ? true : false;
 
@@ -15,7 +17,7 @@ const UserInfo = ({userData}:any) => {
       <S.Image src={IMG_URL} />
       <S.Name>{userData.nickname}</S.Name>
       <S.Introduce>{userData.about}</S.Introduce>
-      {isMypage? <S.Button onClick={() => router.push({pathname:"/modify"})}>프로필 수정</S.Button> : <JoinRequestModal name={userData.nickname} title={"초대하기"} text={"누구누구 초대하기"} id={userData.id}/>}
+      {isMypage? <S.Button onClick={() => router.push({pathname:"/modify"})}>프로필 수정</S.Button> : <JoinRequestModal name={userData.nickname} id={userData.id} userId={userId}/>}
     </S.Container>
   );
 };

--- a/src/hooks/useMissionEdit.ts
+++ b/src/hooks/useMissionEdit.ts
@@ -2,8 +2,8 @@ import { studyApi } from "@/api/studyApi";
 import { toast } from "react-toastify";
 import { useRouter } from "next/router";
 import { useState } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import * as userAction from "@/store/modules/missionProblem";
+import { useDispatch } from "react-redux";
+import * as userAction from "@/store/modules/mission";
 
 interface IProblemList {
   problemName : string;

--- a/src/hooks/useStudyEdit.ts
+++ b/src/hooks/useStudyEdit.ts
@@ -1,17 +1,12 @@
 import { studyApi } from "@/api/studyApi";
 import { useState } from "react";
-import { USER_NUMBER } from "@/util/constant";
 import { toast } from "react-toastify";
 import { useRouter } from "next/router";
 
 interface IArgument {
   nameValue : string;
   aboutValue : string;
-}
-
-interface ISubmit {
-  e : React.FormEvent<HTMLFormElement>;
-  isEditMode : boolean;
+  userId : number;
 }
 
 const useStudyEdit = () => {
@@ -20,9 +15,9 @@ const useStudyEdit = () => {
   const [createStudy] = studyApi.useCreateStudyMutation();
   const [updateStudy] = studyApi.useUpdateStudyMutation();
 
-  const handleCreateStudy = async({nameValue, aboutValue}: IArgument) => {
+  const handleCreateStudy = async({nameValue, aboutValue, userId}: IArgument) => {
     try{
-      await createStudy({"member":USER_NUMBER, "name":nameValue, "about":aboutValue, "leader":"leader","capacity":maxStudyCapacity});
+      await createStudy({"member":userId, "name":nameValue, "about":aboutValue, "leader":"leader","capacity":maxStudyCapacity});
       toast('스터디 생성 완료')
       router.push({pathname:"/profile"})
     }catch(err){
@@ -30,7 +25,7 @@ const useStudyEdit = () => {
     }
   }
   
-  const handleUpdateStudy = async({nameValue, aboutValue}: IArgument) => {
+  const handleUpdateStudy = async({nameValue, aboutValue, userId}: IArgument) => {
     try{
       await updateStudy({"id": router.query.id, "name":nameValue, "about":aboutValue,"capacity":maxStudyCapacity})
       toast('스터디 수정 완료')

--- a/src/hooks/useUpdateUserInfo.ts
+++ b/src/hooks/useUpdateUserInfo.ts
@@ -1,18 +1,17 @@
 import { memberApi } from "@/api/memberApi";
 import { toast } from "react-toastify";
-import { USER_NUMBER } from "@/util/constant";
 
 interface IArgument {
   nameValue: string;
   aboutValue : string;
 }
 
-const useUpdateUserInfo = () => {
+const useUpdateUserInfo = (userId:number) => {
   const [updateUserInfo] = memberApi.useUpdateMemberMutation();
 
   const handleUpdateUserInfo = async({nameValue, aboutValue}:IArgument) => {
     try{
-      await updateUserInfo({"id":USER_NUMBER, "nickname":nameValue, "about":aboutValue})
+      await updateUserInfo({"id":userId, "nickname":nameValue, "about":aboutValue})
       toast('정보 수정 완료')
     }catch(err){
       console.log(err); 

--- a/src/pages/member/[detail].tsx
+++ b/src/pages/member/[detail].tsx
@@ -10,6 +10,9 @@ import { studyApi } from "@/api/studyApi";
 import { useRouter } from "next/router";
 import { memberApi } from "@/api/memberApi";
 import Loading from "@/components/Loading/Loading";
+import { GetServerSideProps } from "next";
+import { parseCookies } from "@/util/parseCookie";
+
 const flag = 0;
 
 export interface IUserData {
@@ -25,8 +28,23 @@ export interface IUserData {
 interface IUserInfo {
   data: IUserData
 }
+
+
+export const getServerSideProps : GetServerSideProps = async(context) => {
+  const {req, res} = context;
+  const cookies = parseCookies(req.headers.cookie)
+  const userId = Number(cookies.memberId)
+  
+  return {
+    props: {
+      userId,
+    },
+  };
+}
+
+
  
-const Profile = () => {
+const Profile = ({userId}:{userId : string}) => {
   const router = useRouter();
   const {detail: param} = router.query;
   const {data: userStudyList, isLoading: isGetUserStudyListLoading} = studyApi.useGetUserStudyListQuery({memberId:param, status:1});
@@ -58,7 +76,7 @@ const Profile = () => {
           </>
         );
       case 1:
-        return <Board type={"study"} category={[["스터디", "name"], ["소개", "about"], ["인원", "capacity"],[ "스터디 장", "leader"],["랭킹", "xp"]]} widthRatio={[1, 2, 1, 1, 1]} data={userStudyList.data.studyList}/>;
+        return <Board type={"study"} category={[["스터디", "name"], ["소개", "about"], ["인원", "capacity"],[ "스터디 장", "leader"],["랭킹", "xp"]]} widthRatio={[1, 2, 1, 1, 1]} data={userStudyList.data.data}/>;
       case 2:
         return <Board type={"study"} category={["스터디", "소개", "인원", "스터디 장", "상태"]} widthRatio={[1, 2, 1, 1, 1]} data={userStudyList.data.studyList}/>;
     }
@@ -66,7 +84,7 @@ const Profile = () => {
   return (
     <S.Container>
       <S.InfoContainer>
-        <UserInfo userData={userData.data}/>
+        <UserInfo userData={userData.data} userId={userId}/>
         <UserSolvedInfo userData={userData.data}/>
       </S.InfoContainer>
       {flag ? <Tab elements={TAB_ELEMENTS_MY} type="profile" /> : <Tab elements={TAB_ELEMENTS_OTHER} type="profile" />}

--- a/src/pages/modify/index.tsx
+++ b/src/pages/modify/index.tsx
@@ -6,15 +6,37 @@ import { memberApi } from "@/api/memberApi";
 import {  useEffect } from "react";
 import {  useRouter } from "next/router";
 import useInput from "@/hooks/useInput";
-import { USER_NUMBER } from "@/util/constant";
 import useUpdateUserInfo from "@/hooks/useUpdateUserInfo";
 import Loading from "@/components/Loading/Loading";
+import { parseCookies } from "@/util/parseCookie";
+import { GetServerSideProps } from "next";
 
-const Modify = () => {
-  const {data, isLoading} = memberApi.useGetMemberQuery(USER_NUMBER);
+interface LoginProps {
+  refreshToken: string;
+  memberId: number;
+}
+
+export const getServerSideProps : GetServerSideProps = async(context) => {
+  const {req, res} = context;
+  const cookies = parseCookies(req.headers.cookie)
+  const refreshToken = cookies.refreshToken
+  const memberId = Number(cookies.memberId)
+  
+  return {
+    props: {
+      refreshToken,
+      memberId,
+    },
+  };
+}
+
+
+const Modify = ({memberId, refreshToken}:LoginProps) => {
+  const {data, isLoading} = memberApi.useGetMemberQuery(memberId);
+  console.log(data);
   const [nameValue, setNameValue, onChangeName] = useInput('')  
   const [aboutValue, setAboutValue, onChangeAbout] = useInput('')
-  const {handleUpdateUserInfo} = useUpdateUserInfo();
+  const {handleUpdateUserInfo} = useUpdateUserInfo(memberId);
   const router = useRouter();
   
   useEffect(() => {
@@ -39,7 +61,7 @@ const Modify = () => {
 
   return (
     <S.Container onSubmit={(e) => onSubmitUpdateUserInfo(e)}>
-      <ModifyImg />
+      <ModifyImg userImg={data.data.kakaoProfileImage}/>
       <Input title={"이름"} size={"25%"} value={nameValue} onChange={onChangeName} />
       <Input title={"자기소개"} size={"25%"} value={aboutValue} onChange={onChangeAbout}/>
       <ModifyButton />

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -26,10 +26,6 @@ export const getServerSideProps : GetServerSideProps = async(context) => {
   const cookies = parseCookies(req.headers.cookie)
   const refreshToken = cookies.refreshToken
   const memberId = Number(cookies.memberId)
-
-  console.log('refresh:', refreshToken);
-  console.log('memberId', memberId);
-  
   
   return {
     props: {

--- a/src/pages/rank/algorithm.tsx
+++ b/src/pages/rank/algorithm.tsx
@@ -5,7 +5,7 @@ import Loading from "@/components/Loading/Loading";
 
 const AlgorithmRank = () => {
   const {data, isLoading} = memberApi.useGetAllMembersQuery({});
-  if(isLoading) return <(
+  if(isLoading) return (
     <S.Container>
       <Loading/>
     </S.Container>

--- a/src/pages/study/[studyId]/index.tsx
+++ b/src/pages/study/[studyId]/index.tsx
@@ -8,36 +8,73 @@ import { useSelector } from "react-redux";
 import SolveStatus from "@/components/common/SolveStatus";
 import { studyApi } from "@/api/studyApi";
 import { useRouter } from "next/router";
-import { mock_data } from "./mission.mock";
+import useFetchUserStudyList from "@/hooks/queries/useFetchUserStudyList";
 import Loading from "@/components/Loading/Loading";
+import { parseCookies } from "@/util/parseCookie";
+import { GetServerSideProps } from "next";
+import { useState, useEffect } from "react";
 
-const StudyDetail = () => {
+interface IServerSideProp {
+  refreshToken: string;
+  memberId: number;
+}
+
+export const getServerSideProps : GetServerSideProps = async(context) => {
+  const {req, res} = context;
+  const cookies = parseCookies(req.headers.cookie)
+  const refreshToken = cookies.refreshToken
+  const memberId = Number(cookies.memberId)
+  
+  return {
+    props: {
+      refreshToken,
+      memberId,
+    },
+  };
+}
+
+const StudyDetail = ({ refreshToken, memberId }: IServerSideProp) => {
   const router = useRouter();
   const {studyId: param} = router.query;
   const {data:studyMissionList, isLoading:getStudyMissionListLoading} = studyApi.useGetStudyRuleListQuery(Number(param));
   const {data:stduyMemberList, isLoading:getMemberListLoading} = studyApi.useGetStudyMemberListQuery(Number(param));
   const {data:studyPedingList, isLoading:getPedingListLoading} = studyApi.useGetPendingListQuery(Number(param));
   const {data:studyInfo, isLoading:getStudyInfoLoading} = studyApi.useGetStudyInfoQuery(Number(param));
-  
-  
+  // 로그인 유저의 스터디 목록
+  const {data: userStudyList, isLoading: isStudyListLoading} = useFetchUserStudyList({memberId,status:1});
+  const [isUserStudy, setIsUserStudy] = useState<boolean>(false);
+
   const tabState = useSelector((state: any) => {
     return state.tab.studyTabState;
   });
   const TAB_ELEMENTS = ["현황", "미션", "멤버", "가입요청"];
+  
+  // 해당 스터디가 현재 유저가 가입된 스터디인지 순회하며 체크
+  useEffect(() => {
+    if(!isStudyListLoading){
+      for(let i=0; i<userStudyList.data.data.length; i++){
+        if(Number(param) === userStudyList.data.data[i].id){
+          setIsUserStudy(true)
+          break
+        }
+      }
+    }
+  }, [isStudyListLoading])
 
-  if(getMemberListLoading || getPedingListLoading || getStudyMissionListLoading || getStudyInfoLoading) return (
+  if(getMemberListLoading || getPedingListLoading || getStudyMissionListLoading || getStudyInfoLoading || isStudyListLoading) return (
     <S.StudyContainer>
-      <StudyInfo />
+      <StudyInfo isUserStudy={isUserStudy} memberId={memberId}/>
       <Tab elements={TAB_ELEMENTS} type="study" />
       <S.ContentContainer>
         <Loading/>
       </S.ContentContainer>
     </S.StudyContainer>
   )
+
   
   return ( 
     <S.StudyContainer>
-      <StudyInfo />
+      <StudyInfo isUserStudy={isUserStudy} memberId={memberId}/>
       <Tab elements={TAB_ELEMENTS} type="study" />
       <S.ContentContainer>
         {tabState === 0 && (
@@ -51,7 +88,7 @@ const StudyDetail = () => {
             </S.StatusContainer>
           </>
         )} 
-        {tabState === 1 && <Board type={"mission"} category={[["규칙", "name"], ["소개", "about"], ["시작일", "startDate"], ["종료일", "deadline"], ["상태", "mission"]]} widthRatio={[1, 2, 1, 1, 1]}  data={mock_data}/>}
+        {tabState === 1 && <Board type={"mission"} category={[["규칙", "name"], ["소개", "about"], ["시작일", "startDate"], ["종료일", "deadline"], ["상태", "mission"]]} widthRatio={[1, 2, 1, 1, 1]}  data={studyMissionList.data}/>}
         {tabState === 2 && <Board type={"member"} category={[["이름", "nickname"], ["랭킹", "ruby"], ["가입한 스터디", "id"]]} widthRatio={[2, 1, 1]} data={stduyMemberList.data}/>}
         {tabState === 3 && <Board type={"join"} category={[["이름", "nickname"], ["랭킹", "ruby"], ["상태", "invite"]]} widthRatio={[1, 1, 1]} data={studyPedingList.data.pending} />}
       </S.ContentContainer>

--- a/src/pages/study/[studyId]/mission/[missionId].tsx
+++ b/src/pages/study/[studyId]/mission/[missionId].tsx
@@ -37,17 +37,19 @@ const MissionDetail = () => {
     {
       rank: 1, 
       nickname : 'chumjio1o',
-      problem_status: [true, true, true, false]
+      problem_status: Array.from({length:PROBLEM_COUNT}, () => true)
     },
     {
       rank: 2,
       nickname : 'jeongdo',
-      problem_status: [false, false, true, false]
+      problem_status: Array.from({length:PROBLEM_COUNT}, () => true)
     }
   ]
 
   for(let i=0; i<DATE_PROGRESS; i++){
+    if(i >= DURATION) break
     TIME_SPAN_STATUS[i] = true;
+    
   }
 
   for(let i=0; i<PROBLEM_COUNT; i++){
@@ -60,8 +62,15 @@ const MissionDetail = () => {
   
   const studyId = router.query.studyId
 
-  const movePage = () => {
-    router.push({pathname:`/study/${studyId}`})
+  const movePage = (type:'study'|'rule') => {
+    switch(type){
+      case 'study':
+        router.push({pathname:`/study/${studyId}`})
+        return
+      case 'rule':
+        router.push({pathname:`/rule/list`})
+        return
+    }
   }
   
   return (
@@ -107,10 +116,10 @@ const MissionDetail = () => {
           </S.MissionProblemListContainer>
         </S.MemberSolvingStatusContainer>
         <S.ButtonContainer>
-          <Button type="primary" style={{width:"100px", height:"40px"}} onClick={movePage}>목록</Button>
+          <Button type="primary" style={{width:"100px", height:"40px"}} onClick={() => movePage('study')}>목록</Button>
           <Button style={{width:"100px", height:"40px"}} type="primary">수정</Button>
           <AlertModal id={param.missionId} title={'미션 삭제'} text={'삭제하시겠습니까 ?'} type={"mission"} backId={param.studyId}>삭제</AlertModal>
-          <Button style={{width:"100px", height:"40px"}} type="primary">규칙 상세보기</Button>
+          <Button style={{width:"100px", height:"40px"}} type="primary" onClick={() => movePage('rule')}>규칙 상세보기</Button>
         </S.ButtonContainer>
       </S.MissionStatusContainer>
     </S.Container>

--- a/src/pages/study/manage.tsx
+++ b/src/pages/study/manage.tsx
@@ -5,8 +5,23 @@ import useInput from "@/hooks/useInput";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import useStudyEdit from "@/hooks/useStudyEdit";
+import { GetServerSideProps } from "next";
+import { parseCookies } from "@/util/parseCookie";
 
-const CreateStudy = () => {
+export const getServerSideProps : GetServerSideProps = async(context) => {
+  const {req, res} = context;
+  const cookies = parseCookies(req.headers.cookie)
+  const userId = Number(cookies.memberId)
+  
+  return {
+    props: {
+      userId,
+    },
+  };
+}
+
+
+const CreateStudy = ({userId}:{userId:number}) => {
   const {maxStudyCapacity, setMaxStudyCapacity, handleCreateStudy, handleUpdateStudy} = useStudyEdit();
   const [nameValue, setNameValue, nameHandler] = useInput('')  
   const [aboutValue, setAboutValue, aboutHandler] = useInput('')
@@ -24,9 +39,9 @@ const CreateStudy = () => {
   const handleSubmit = (e:React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if(isEditMode){
-      handleUpdateStudy({nameValue, aboutValue})
+      handleUpdateStudy({nameValue, aboutValue, userId})
     }else{
-      handleCreateStudy({nameValue, aboutValue})
+      handleCreateStudy({nameValue, aboutValue, userId})
     }
   }
 

--- a/src/pages/study/rule.tsx
+++ b/src/pages/study/rule.tsx
@@ -28,7 +28,7 @@ const Mission = () => {
 
   
   const missionProblemState = useSelector((state:any) => {
-    return state.missionProblem.missionProblemState
+    return state.mission.missionProblemState
   })
 
   useEffect(() => {


### PR DESCRIPTION
## 개요 :mag:
- 지금까지 로그인된 유저를 임의로 USER_NUMBER 상수로 설정하고 API 테스트를 진행했었는데, 로그인 유저의 Id로 수정
- 스터디 페이지에서 로그인 유저가 해당 스터디에 가입 여부에 따라서 버튼 분기처리
가입된 스터디일 경우 : [미션 만들기, 스터디 수정하기]
가입되지 않은 스터디일 경우 : [스터디 가입하기]

추후에 유저의 role에 따라서 
leader일 경우만 [미션 만들기, 스터디 수정하기]  버튼이 보이도록 수정할 예정

#44 